### PR TITLE
Fixes to PyYAML Version issue and reboot issue

### DIFF
--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -162,7 +162,7 @@ class manager:
                 bootbinpath=uimagepath, uimagepath=uimagepath, devtreepath=devtreepath
             )
             log.info("Waiting for reboot to complete")
-            time.sleep(30)
+            time.sleep(60)
 
         except (ne.LinuxNotReached, TimeoutError):
             # Power cycle
@@ -194,7 +194,7 @@ class manager:
                 )
             # NEED A CHECK HERE OR SOMETHING
             log.info("Waiting for boot to complete")
-            time.sleep(30)
+            time.sleep(60)
 
         # Check is networking is working
         if self.net.ping_board():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyfiglet
 fabric
-pyyaml
+pyyaml>=5.1
 pyserial
 pytest
 pyvesync_v2


### PR DESCRIPTION
Forced version of PyYAML version to 5.1. 
Extended waiting time for reboot to 60s since there are projects that takes longer time to reboot.