### PR TITLE
New folder structure download support

### DIFF
--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -54,11 +54,15 @@ def gen_url(ip, branch, folder, filename, url_template):
     url = url_template.format(ip, branch, "", "")
     # folder = BUILD_DATE/PROJECT_FOLDER
     folder = get_newest_folder(listFD(url[:-1]))+'/'+folder
+    print(url_template.format(ip, branch, folder, filename))
     return url_template.format(ip, branch, folder, filename)
 
 
 class downloader(utils):
-    def __init__(self, http_server_ip=None, yamlfilename=None, board_name=None):
+    def __init__(self, http_server_ip=None, yamlfilename=None, board_name=None, reference_boot_folder=None, devicetree_subfolder=None, boot_subfolder=None):
+        self.reference_boot_folder = None
+        self.devicetree_subfolder = None
+        self.boot_subfolder = None
         self.http_server_ip = http_server_ip
         self.update_defaults_from_yaml(
             yamlfilename, __class__.__name__, board_name=board_name
@@ -137,7 +141,7 @@ class downloader(utils):
         self.download(url, filename)
 
     def _get_files(
-        self, design_name, details, source, source_root, branch, firmware=False
+        self, design_name, reference_boot_folder, devicetree_subfolder, boot_subfolder, details, source, source_root, branch, firmware=False
     ):
         kernel = False
         kernel_root = False
@@ -175,22 +179,34 @@ class downloader(utils):
                 kernel_root = os.path.join(source_root, kernel_root)
                 design_source_root = os.path.join(source_root, design_name)
             else:
-                design_source_root = design_name
+                design_source_root = reference_boot_folder
             print("Get standard boot files")
             # Get kernel
             print("Get", kernel)
+            print(design_source_root)
             self._get_file(kernel, source, kernel_root, source_root, branch)
+            
+            if boot_subfolder is not None:
+                design_source_root = reference_boot_folder+ '/' +str(boot_subfolder)
+            else:
+                design_source_root = reference_boot_folder
             # Get BOOT.BIN
+            print(design_source_root)
             print("Get BOOT.BIN")
             self._get_file("BOOT.BIN", source, design_source_root, source_root, branch)
-            # Get device tree
-            print("Get", dt)
-            self._get_file(dt, source, design_source_root, source_root, branch)
             # Get support files (bootgen_sysfiles.tgz)
             print("Get support")
             self._get_file(
                 "bootgen_sysfiles.tgz", source, design_source_root, source_root, branch
             )
+            # Get device tree
+            print("Get", dt)
+            if devicetree_subfolder is not None:
+                design_source_root = reference_boot_folder+ '/' +str(devicetree_subfolder)
+            else:
+                design_source_root = reference_boot_folder
+            print(design_source_root)
+            self._get_file(dt, source, design_source_root, source_root, branch)
 
     def download_boot_files(
         self,
@@ -206,6 +222,7 @@ class downloader(utils):
 
             Parameters:
                 design_name: Target design name (same as boot file folder on SD card)
+                dtb_folder: Applicable to target design name with sub-folder for devicetree (name of sub-folder)
                 source: Source location type. Options: local_fs, http, artifactory
                 source_root: Root location of files. Dependent on source parameter
                     For local_fs this is a system path
@@ -225,8 +242,15 @@ class downloader(utils):
 
         assert design_name in board_configs, "Invalid design name"
 
+        reference_boot_folder = self.reference_boot_folder
+        devicetree_subfolder = self.devicetree_subfolder
+        boot_subfolder = self.boot_subfolder
+
         self._get_files(
             design_name,
+            reference_boot_folder,
+            devicetree_subfolder,
+            boot_subfolder,
             board_configs[design_name],
             source,
             source_root,

--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -54,7 +54,6 @@ def gen_url(ip, branch, folder, filename, url_template):
     url = url_template.format(ip, branch, "", "")
     # folder = BUILD_DATE/PROJECT_FOLDER
     folder = get_newest_folder(listFD(url[:-1]))+'/'+folder
-    print(url_template.format(ip, branch, folder, filename))
     return url_template.format(ip, branch, folder, filename)
 
 
@@ -183,7 +182,6 @@ class downloader(utils):
             print("Get standard boot files")
             # Get kernel
             print("Get", kernel)
-            print(design_source_root)
             self._get_file(kernel, source, kernel_root, source_root, branch)
             
             if boot_subfolder is not None:
@@ -191,7 +189,6 @@ class downloader(utils):
             else:
                 design_source_root = reference_boot_folder
             # Get BOOT.BIN
-            print(design_source_root)
             print("Get BOOT.BIN")
             self._get_file("BOOT.BIN", source, design_source_root, source_root, branch)
             # Get support files (bootgen_sysfiles.tgz)
@@ -205,7 +202,6 @@ class downloader(utils):
                 design_source_root = reference_boot_folder+ '/' +str(devicetree_subfolder)
             else:
                 design_source_root = reference_boot_folder
-            print(design_source_root)
             self._get_file(dt, source, design_source_root, source_root, branch)
 
     def download_boot_files(
@@ -222,7 +218,6 @@ class downloader(utils):
 
             Parameters:
                 design_name: Target design name (same as boot file folder on SD card)
-                dtb_folder: Applicable to target design name with sub-folder for devicetree (name of sub-folder)
                 source: Source location type. Options: local_fs, http, artifactory
                 source_root: Root location of files. Dependent on source parameter
                     For local_fs this is a system path

--- a/nebula/resources/board_table.yaml
+++ b/nebula/resources/board_table.yaml
@@ -167,6 +167,10 @@ zynq-zed-adv7511-ad9467-fmc-250ebz:
   addons:
   - AD9467-FMC-250EBZ
   carrier: Zed-Board
+zynq-zed-adrv9002:
+  addons:
+  - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
+  carrier: Zed-Board
 zynq-zed-adv7511-cn0363:
   addons:
   - EVAL-CN0363-PMDZ

--- a/nebula/resources/template_gen.yaml
+++ b/nebula/resources/template_gen.yaml
@@ -12,21 +12,16 @@
 board-config:
   field_1:
     name: board-name
-    default: zynq-zc706-adv7511-fmcdaq2
-    help: "Board plus carrier name used by hdl project.\nThis is usually the same as the boot folder name of the AD-FMC-SDCARD"
+    default: zynq-zc702-adv7511-ad9361-fmcomms2-3
+    help: "Board plus carrier name used by hdl project.\nThis is usually the same as the boot folder name of the AD-FMC-SDCARD."
     optional: False
-  field_2:
-    name: reference-boot-folder
-    default: zynq-zc706-adv7511-fmcdaq2
-    help: "Folder name where reference boot files exit for specific board"
-    optional: False
-  field_3:
+  field_4:
     name: monitoring-interface
     default: uart
     help: "Select monitoring interface"
     options: [uart, netconsole]
     optional: False
-  field_4:
+  field_5:
     name: allow-jtag
     default: False
     help: "Allow use of JTAG"
@@ -124,6 +119,21 @@ downloader-config:
     default: 192.168.2.1
     help: "IP address of build server with boot files"
     optional: True
+  field_2:
+    name: reference_boot_folder
+    default: zynq-zc702-adv7511-ad9361-fmcomms2-3-4
+    help: "Folder name where reference boot files exist for specific board. \nThis is the same as the boot folder name of the AD-FMC-SDCARD."
+    optional: False
+  field_3:
+    name: devicetree_subfolder
+    default: zynq-zc702-adv7511-ad9361-fmcomms2-3
+    help: "Subfolder name where devicetree files exists for specific boards."
+    optional: False
+  field_4:
+    name: boot_subfolder
+    default: boot_bin_CMOS
+    help: "Subfolder name where boot files exist for specific boards."
+    optional: False
 jtag-config:
   field_1:
     name: vivado_version

--- a/nebula/resources/template_gen.yaml
+++ b/nebula/resources/template_gen.yaml
@@ -15,13 +15,13 @@ board-config:
     default: zynq-zc702-adv7511-ad9361-fmcomms2-3
     help: "Board plus carrier name used by hdl project.\nThis is usually the same as the boot folder name of the AD-FMC-SDCARD."
     optional: False
-  field_4:
+  field_2:
     name: monitoring-interface
     default: uart
     help: "Select monitoring interface"
     options: [uart, netconsole]
     optional: False
-  field_5:
+  field_3:
     name: allow-jtag
     default: False
     help: "Allow use of JTAG"

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -124,7 +124,7 @@ def download_sdcard(c, release="2019_R1"):
 
 @task(
     help={
-        "board_name": "Board configuration name. Ex: zynqmp-zcu102-rev10-adrv9371",
+        "board_name": "Board configuration name. Ex: zynq-zc702-adv7511-ad9361-fmcomms2-3",
         "source": "Boot file download source. Options are: local_fs, http, artifactory, remote.\nDefault: local_fs",
         "source_root": "Location of source boot files. Dependent on source.\nFor http sources this is a IP or domain name (no http://)",
         "branch": "Name of branch to get related files. This is only used for\bhttp and artifactory sources. Default is master",
@@ -143,7 +143,7 @@ def download_boot_files(
 ):
     """ Download bootfiles for a specific development system """
     d = nebula.downloader(yamlfilename=yamlfilename, board_name=board_name)
-    d.download_boot_files(board_name, source, source_root, branch)
+    d.download_boot_files(board_name,  source, source_root, branch)
 
 
 dl = Collection("dl")

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -143,7 +143,7 @@ def download_boot_files(
 ):
     """ Download bootfiles for a specific development system """
     d = nebula.downloader(yamlfilename=yamlfilename, board_name=board_name)
-    d.download_boot_files(board_name,  source, source_root, branch)
+    d.download_boot_files(board_name, source, source_root, branch)
 
 
 dl = Collection("dl")


### PR DESCRIPTION
This pull request will enable the download of files from the new folder structure of the boot partition folder.
In the nebula YAML file, the following fields under downloader-config should be added.

- reference_boot_folder - Folder name where reference boot files exist for the specific board. This is the same as the boot folder name of the AD-FMC-SDCARD.
- devicetree_subfolder - Subfolder name where device tree files exist for specific boards. If there is no subfolder for the device tree file, this is not declared.
- boot_subfolder - subfolder name where boot files exist for specific boards. If there is no subfolder for the boot file, this is not declared. Created to cater zcu102-adrv9002 project where it has boot subfolders.

These fields are used to define the 'design_source_root' which will then be used to generate the URL of the file to be downloaded.

Also added, zynq-zed-adrv9002 to the board_table.yaml.