### PR TITLE
Some fixes to jtag issues encountered in test

### DIFF
--- a/nebula/jtag.py
+++ b/nebula/jtag.py
@@ -64,8 +64,12 @@ class jtag(utils):
     def restart_board(self):
         cmd = "connect; "
         cmd += "after 3000; "
-        cmd += "targets 1; "
+        cmd += "puts [jtag target]; "
+        cmd += self.target_set_str("APU")
+        cmd += "puts {Reset System}; "
+        cmd += "after 1000; "
         cmd += "rst -system; "
+        cmd += "after 1000; "
         cmd += "con"
         self.run_xsdb(cmd)
 

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -162,7 +162,7 @@ class manager:
                 log.info("Waiting for boot to complete")
 
                 # Verify uboot anad linux are reached
-                results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=30)
+                results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=100)
 
                 if len(results)==1:
                     # raise Exception("u-boot not reached")
@@ -245,7 +245,7 @@ class manager:
         self.power.power_cycle_board()
         try:
             log.info("Waiting for boot to complete")
-            results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=60)
+            results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=100)
         except Exception as ex:
             # Try to reinitialize uart and manually boot via u-boot 
             log.warning("UART is unavailable.")
@@ -255,7 +255,7 @@ class manager:
             self.monitor[0].reinitialize_uart()
             self.jtag.restart_board()
             log.info("Waiting for boot to complete")
-            results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=60)
+            results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=100)
 
 
         if len(results)==1:
@@ -341,7 +341,7 @@ class manager:
             log.info("Waiting for reboot to complete")
 
             # Verify uboot anad linux are reached
-            results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=30)
+            results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=100)
 
             if len(results)==1:
                 raise Exception("u-boot not reached")

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -80,6 +80,13 @@ class uart(utils):
         if self.com:
             self.com.close()
 
+    def reinitialize_uart(self):
+        log.info("Reinitializing UART")
+        if self.com:
+            self.com.close()
+            self.com = serial.Serial(self.address, self.baudrate, timeout=5)
+            self.com.reset_input_buffer()
+
     def _auto_set_address(self):
         """ Try to set yaml automatically """
         if os.name in ["nt", "posix"]:


### PR DESCRIPTION
1. specify jtag target for method restart_board
2.  handle uart i/o error after power cycle
3.  increase max time of _read_until_done_multi to 100